### PR TITLE
[codex] Fix exit order safety guards

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -210,7 +210,7 @@ IDLE ──(信号触发)──▶ PLACING ──(下单成功)──▶ WAITING
 | `MAKER_ONLY` | Post-only 限价（GTX），享受 Maker 费率 | 默认模式，流动性充足时 |
 | `AGGRESSIVE_LIMIT` | 普通限价（GTC），价格更贴近成交方向 | Maker 连续超时后自动升级 |
 
-补充：`long_bid_improve` / `short_ask_improve` 信号触发时，系统会直接切换到 `AGGRESSIVE_LIMIT` 并在同一轮信号内提交限价单（仍可能因盘口变化未立即成交）。
+补充：`long_bid_improve` / `short_ask_improve` 信号触发时，系统会先用当前盘口重新确认机会仍成立；若仍成立，会直接切换到 `AGGRESSIVE_LIMIT` 并在同一轮信号内提交限价单（仍可能因盘口变化未立即成交）。
 
 `orderbook_pressure` 复用同一套执行状态机，但信号会自带 `price_override` / `ttl_override_ms` / `cooldown_override_ms` / `base_mult_override` / `qty_jitter_pct`：
 - 主动条件成立：LONG 下 `SELL @ best_bid`，SHORT 下 `BUY @ best_ask`
@@ -219,7 +219,7 @@ IDLE ──(信号触发)──▶ PLACING ──(下单成功)──▶ WAITING
 
 ## 倍数系统
 
-最终下单数量 = `base_mult × roi_mult × accel_mult`（受 `max_mult` 和 `max_order_notional` 约束）
+最终下单数量 = `base_mult × roi_mult × accel_mult`（受 `max_mult` 和基于订单限价的 `max_order_notional` 约束）
 
 ### ROI 倍数（`roi_mult`）
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,7 +267,7 @@ symbols:
 - **类型**: `decimal`
 - **默认值**: `200`
 - **单位**: USDT
-- **说明**: 单笔订单最大名义价值，`notional = quantity × price`
+- **说明**: 单笔订单最大名义价值，`notional = quantity × order_limit_price`
 - **目的**: 限制单笔订单的市场冲击和风险暴露
 - **调优建议**:
   - 小仓位: `100-300 USDT`
@@ -776,7 +776,7 @@ symbols:
   - `use_roi_mult`: 是否对基准片大小叠加公共 `roi_mult`；未配置时继承 `execution.use_roi_mult`
   - `use_accel_mult`: 是否对基准片大小叠加公共 `accel_mult`；未配置时继承 `execution.use_accel_mult`
   - 当上述开关启用时，数量会在 `execution.base_mult` 对应的基准片大小上叠加公共倍数，并继续受 `execution.max_mult` 硬上限约束
-  - 该路径同样受 `execution.max_order_notional` 约束；若单笔名义价值上限过低，规整后数量可能直接变成 `0`
+  - 该路径同样受基于订单限价计算的 `execution.max_order_notional` 约束；若单笔名义价值上限过低，规整后数量可能直接变成 `0`
   - `qty_jitter_pct`: 基准片大小的最终下单量随机抖动比例（`0` = 关闭）；以规整后的最终数量为中心做双边 jitter，再 clamp 到剩余仓位
   - `qty_anti_repeat_lookback`: 基准片大小 anti-repeat 回看笔数；会尽量避开最近几笔已成功提交的相同数量（`0` = 关闭）
   - 主动路径节奏
@@ -831,7 +831,7 @@ symbols:
 - 主动条件未成立时，仅挂 1 笔固定档位的被动单
 - 被动档位不存在或盘口数据不完整时，本轮跳过，不猜价格
 - `bookTicker` 与 `depth10` 任一来源 stale 时，本轮跳过，并重置主动条件 dwell
-- 新模式默认继承 `execution.use_roi_mult` / `execution.use_accel_mult`；若在 `pressure_exit.use_*` 显式配置，则以 pressure 自己的值为准。启用后会在 `execution.base_mult` 对应的基准片大小上叠加公共倍数，并同时受 `execution.max_mult` 与 `execution.max_order_notional` 约束
+- 新模式默认继承 `execution.use_roi_mult` / `execution.use_accel_mult`；若在 `pressure_exit.use_*` 显式配置，则以 pressure 自己的值为准。启用后会在 `execution.base_mult` 对应的基准片大小上叠加公共倍数，并同时受 `execution.max_mult` 与基于订单限价计算的 `execution.max_order_notional` 约束
 - `qty_jitter_pct` 作用在最终规整后的基准片大小，不再通过缩窄 `base_mult` 来单边抖动
 - `qty_anti_repeat_lookback` 只参考最近几笔已成功提交的 `orderbook_pressure` 订单数量
 - `active_recheck_cooldown_jitter_pct` / `passive_ttl_jitter_pct` 分别作用于主动冷却和被动 TTL，避免固定节拍过于显眼

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -1,5 +1,5 @@
 <!-- Input: 系统模块、运行方式与关键约束 -->
-<!-- Output: 架构与文件结构说明（含 Telegram Bot 命令控制/暂停恢复、交易所初始化诊断、按 symbol 策略模式、执行竞态/自恢复安全约束、一级风控日志降噪与 -4118 挂单占仓锁存） -->
+<!-- Output: 架构与文件结构说明（含 Telegram Bot 命令控制/暂停恢复、交易所初始化诊断、按 symbol 策略模式、执行竞态/自恢复安全约束、orderbook_price 当前盘口重校验、一级风控日志降噪与 -4118 挂单占仓锁存） -->
 <!-- Pos: memory-bank/architecture 总览与执行状态机约束 -->
 <!-- 一旦我被更新，务必更新我的开头注释，以及所属文件夹的MD。 -->
 # 系统架构
@@ -90,7 +90,7 @@ Binance U 本位永续 Hedge 模式 Reduce-Only 小单平仓执行器。
 | **WSClient** | 订阅 bookTicker + aggTrade + markPrice@1s；对 `orderbook_pressure` symbol 额外订阅 `depth10@100ms`；断线重连，重连后回调触发校准 | 配置 | MarketEvent, OrderUpdate, AlgoOrderUpdate, PositionUpdate, LeverageUpdate |
 | **ExchangeAdapter** | ccxt 封装：markets/positions/balance 查询，下单/撤单（普通/条件单分离，混合场景用 cancel_any_order）；启动期 `load_markets()` 对网络类失败做有限重试，并输出 proxy/direct 诊断；在 `-4118` 后复核同侧普通平仓挂单是否已覆盖剩余可交易仓位 | 配置, OrderIntent | OrderResult, Position |
 | **SignalEngine** | 按 symbol 在 `orderbook_price` / `orderbook_pressure` 两条互斥路径间评估平仓条件；维护 prev/last trade price、盘口量 dwell、active burst pacing 与来源 freshness；产出公共 ROI/accel sizing context；`orderbook_pressure` 生成带 TTL/cooldown jitter、基准片大小 jitter 与 burst pacing 元数据的 ExitSignal，并可显式启用公共倍数 | MarketEvent, Position | ExitSignal |
-| **ExecutionEngine** | 复用单套状态机；支持 signal 自带 `price/ttl/cooldown/base_mult/jitter` 覆盖，并维持 reduce-only 边界；对 `orderbook_pressure` 的基准片大小在最终可下单量上应用公共 roi/accel modifiers、双边 jitter 与 recent-size anti-repeat；`-4118` 后锁存“同侧挂单占仓”状态并暂停无效重试；一级风控持续时保持 `AGGRESSIVE_LIMIT`，避免 maker/aggressive 抖动 | ExitSignal, 配置 | OrderIntent |
+| **ExecutionEngine** | 复用单套状态机；支持 signal 自带 `price/ttl/cooldown/base_mult/jitter` 覆盖，并维持 reduce-only 边界；对 `orderbook_pressure` 的基准片大小在最终可下单量上应用公共 roi/accel modifiers、双边 jitter 与 recent-size anti-repeat；`max_order_notional` 使用本次订单限价作为硬约束价格；`-4118` 后锁存“同侧挂单占仓”状态并暂停无效重试；一级风控持续时保持 `AGGRESSIVE_LIMIT`，避免 maker/aggressive 抖动 | ExitSignal, 配置 | OrderIntent |
 | **RiskManager** | 强平距离兜底（dist_to_liq）+ 全局限速（orders/cancels） | Position, MarketEvent | RiskFlag |
 | **Logger** | 按天滚动日志，结构化字段；维护 `pressure_regime_state.json` 供短暂停机恢复，恢复时按每个 `symbol|side` 的最近 snapshot freshness 过滤 stale cache；支持输出启动后的 `PRESSURE_RECAP` 与运行期连续 `PRESSURE_REPORT` | 各模块事件 | 日志文件 |
 | **Notifier** | Telegram 通知（串行发送 + retry_after 限流等待）+ Bot 命令接收（暂停/恢复/状态查询，`/status` 可查看最近一次 `PRESSURE_REGIME` 缓存） | 关键事件、Bot 命令 | 消息推送、暂停控制 |
@@ -162,11 +162,12 @@ Binance U 本位永续 Hedge 模式 Reduce-Only 小单平仓执行器。
 ### 策略模式（已实现）
 
 - `orderbook_price`：沿用原有 trade + bookTicker 信号、ROI/accel 数量体系与模式轮转
+  - 下单前会用当前 `MarketState` 重新确认 LONG/SHORT 的有利盘口条件仍成立；若盘口已经回落或成交价上下文缺失，本轮跳过，不把过期机会信号传给执行层
 - `orderbook_pressure`：按 symbol 显式启用；同一 symbol 上与 `orderbook_price` 互斥
   - LONG 观察 `best_bid_qty`，SHORT 观察 `best_ask_qty`
   - 顶档量连续超过阈值 `sustain_ms` 后，主动吃一档（LONG=`SELL @ best_bid`，SHORT=`BUY @ best_ask`）
   - 主动条件未成立时，仅保留 1 笔固定档位的被动单（LONG=`ask[passive_level]`，SHORT=`bid[passive_level]`）
-  - 数量基准为 `min_qty × execution.base_mult`；默认继承 `execution.use_roi_mult` / `execution.use_accel_mult`，也可通过 `pressure_exit.use_roi_mult` / `pressure_exit.use_accel_mult` 显式覆盖，并继续受 `execution.max_mult`、`execution.max_order_notional` 与剩余仓位约束
+  - 数量基准为 `min_qty × execution.base_mult`；默认继承 `execution.use_roi_mult` / `execution.use_accel_mult`，也可通过 `pressure_exit.use_roi_mult` / `pressure_exit.use_accel_mult` 显式覆盖，并继续受 `execution.max_mult`、基于本次订单限价的 `execution.max_order_notional` 与剩余仓位约束
   - `bookTicker` 与 `depth10` 任一来源超过 `stale_data_ms` 未刷新时，本轮跳过并重置 dwell
 
 ---

--- a/memory-bank/design-document.md
+++ b/memory-bank/design-document.md
@@ -1,5 +1,5 @@
 <!-- Input: 需求与设计目标 -->
-<!-- Output: 设计方案与约束（含执行反馈/成交率策略与自动发现持仓） -->
+<!-- Output: 设计方案与约束（含执行反馈/成交率策略、自动发现持仓、orderbook_price 当前盘口重校验与订单限价名义金额约束） -->
 <!-- Pos: memory-bank/design-document -->
 <!-- 一旦我被更新，务必更新我的开头注释，以及所属文件夹的MD。 -->
 
@@ -121,11 +121,12 @@ short_exit_condition_met = short_primary or short_ask_improve
 **improve 信号触发路径（简化）**：
 ```text
 MarketEvent -> SignalEngine 判定 improve
+           -> Application 用当前 MarketState 重校验机会仍成立
            -> ExecutionEngine 切到 AGGRESSIVE_LIMIT
            -> on_signal 生成 AGGRESSIVE_LIMIT 限价单
            -> 立即下单（同一轮信号内）
 ```
-说明：仍为 LIMIT 单（SELL=best_bid / BUY=best_ask），成交取决于盘口与状态机是否处于 IDLE。  
+说明：仍为 LIMIT 单（SELL=best_bid / BUY=best_ask），成交取决于盘口与状态机是否处于 IDLE；若下单前当前盘口已不再满足 `orderbook_price` 的 LONG/SHORT 有利条件，本轮信号跳过。  
 
 ### 4.3 状态机（每侧）
 - `IDLE` → `PLACE` → `WAIT` → (`FILLED` | `TIMEOUT`) → `CANCEL` → `COOLDOWN` → `IDLE`
@@ -195,7 +196,7 @@ maker 订单要求：
 - `final_mult = base_mult * roi_mult * accel_mult`
 - 保险 1：`final_mult = min(final_mult, max_mult)`（每 symbol 可覆盖；用户可设很高，但建议更保守）
 - 保险 2：`max_order_notional`（强烈建议启用）
-  - `order_notional = qty * last_trade_price`
+  - `order_notional = qty * order_limit_price`
   - `orderbook_price` 与 `orderbook_pressure` 的正常下单路径都受此约束
   - 若超限：缩小 `qty` 直至满足
 - 最终目标数量：
@@ -421,12 +422,12 @@ def choose_mode(side_state, cfg, risk_flag):
         return "MAKER_ONLY"
     return side_state.mode
 
-def compute_qty(pos_amt_abs, minQty, stepSize, last_trade, mult, cfg):
+def compute_qty(pos_amt_abs, minQty, stepSize, order_price, mult, cfg):
     mult = min(mult, cfg.max_mult)
     qty = min(pos_amt_abs, minQty * mult)
     qty = clamp_to_step(qty, stepSize)
     if cfg.max_order_notional is not None:
-        while qty > 0 and qty * last_trade > cfg.max_order_notional:
+        while qty > 0 and qty * order_price > cfg.max_order_notional:
             qty = clamp_to_step(qty - stepSize, stepSize)
     return qty
 
@@ -437,17 +438,21 @@ def tick_side(side):
     risk_flag = risk_liq_close(side)
     mode = choose_mode(side_state, cfg, risk_flag)
 
+    if mode == "MAKER_ONLY":
+        price = build_maker_price(side, best_bid, best_ask, tickSize, cfg.maker_price_mode, cfg.maker_n_ticks)
+    elif mode == "AGGRESSIVE_LIMIT":
+        price = build_aggressive_price(side, best_bid, best_ask)
+    price = clamp_to_tick(price)
+
     base_mult = strategy_base_mult(side)  # 例如两种策略都来自 base_mult
     mult = base_mult * roi_mult(side) * accel_mult(side)
-    qty = compute_qty(abs(pos.amt), minQty, stepSize, last_trade_price, mult, cfg)
+    qty = compute_qty(abs(pos.amt), minQty, stepSize, price, mult, cfg)
     if qty <= 0: return
 
     if mode == "MAKER_ONLY":
-        price = build_maker_price(side, best_bid, best_ask, tickSize, cfg.maker_price_mode, cfg.maker_n_ticks)
-        place_post_only_limit_reduce_only(side, qty, clamp_to_tick(price))
+        place_post_only_limit_reduce_only(side, qty, price)
     elif mode == "AGGRESSIVE_LIMIT":
-        price = build_aggressive_price(side, best_bid, best_ask)
-        place_limit_reduce_only(side, qty, clamp_to_tick(price))
+        place_limit_reduce_only(side, qty, price)
 
     wait_until_ttl_then_cancel_if_needed()
 ```

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,5 @@
 <!-- Input: 开发进度、里程碑、缺陷修复与相关性分析结论 -->
-<!-- Output: 可追溯的变更与状态（含 Telegram Bot 命令控制/暂停恢复、交易所初始化诊断、执行竞态/自恢复安全修复、一级风控日志降噪、-4118 挂单占仓收口与 PRESSURE_STATS 判读规则）-->
+<!-- Output: 可追溯的变更与状态（含 Telegram Bot 命令控制/暂停恢复、交易所初始化诊断、执行竞态/自恢复安全修复、orderbook_price 当前盘口重校验、订单限价名义金额约束、一级风控日志降噪、-4118 挂单占仓收口与 PRESSURE_STATS 判读规则）-->
 <!-- Pos: memory-bank/progress 维护日志、变更记录与竞态修复 -->
 <!-- 一旦我被更新，务必更新我的开头注释，以及所属文件夹的MD。 -->
 # 开发进度日志
@@ -25,6 +25,20 @@
 | 定时暂停（/pause 支持时长参数） | ✅ |
 | 修复保护止损交叉保证金方向异常 | ✅ |
 | 修复保护止损同步调度竞态 | ✅ |
+
+## Milestone/附加改进：退出机会与订单名义金额硬约束
+
+**状态**：✅ 已完成<br>
+**日期**：2026-06-13
+
+**动机**：平仓机会信号生成后，盘口可能在下单前发生变化；同时 `orderbook_pressure` 在没有最近成交价时仍应受 `max_order_notional` 硬约束。需要保证过期的 `orderbook_price` 机会不会继续传入执行层，并让单笔名义金额上限以本次订单限价为准。<br>
+**产出**：
+
+- `src/main.py`：`orderbook_price` 信号进入执行层前，使用当前 `MarketState` 重新确认 LONG/SHORT 有利盘口条件；若当前盘口不再满足条件，本轮信号跳过。风险触发的 `AGGRESSIVE_LIMIT` 模式提升仍保留，不依赖过期机会信号下单。
+- `src/execution/engine.py`：先解析本次订单限价，再用该限价约束 `compute_qty()` 的 `max_order_notional`；jitter 候选上限也使用同一价格，避免 `last_trade_price=0` 时绕过单笔名义金额上限。
+- `tests/test_main_shutdown.py`：覆盖 `orderbook_price` 机会消失后不调用执行层。
+- `tests/test_execution.py`：覆盖 `orderbook_pressure` 在 `last_trade_price=0` 时仍按订单限价裁剪数量。
+- `memory-bank/architecture.md` / `memory-bank/design-document.md`：同步当前下单前重校验与订单限价名义金额约束语义。
 
 ## Milestone/附加改进：`PRESSURE_REGIME` 在线状态机
 

--- a/src/execution/engine.py
+++ b/src/execution/engine.py
@@ -1,6 +1,6 @@
 # Input: ExitSignal, OrderUpdate, OrderResult, config, rules
-# Output: OrderIntent and per-side execution state transitions (including fill-rate feedback/TTL override, reconcile-safe timeout/preempt/orphan recovery, reduce-only block latching, liq-distance-aware mode holding, and pressure qty jitter/anti-repeat with optional shared sizing modifiers)
-# Pos: per-side execution state machine with WS/REST fill meta handling, terminal-state recovery, panic-close-safe orphan repair, same-side close-order block handling, liq-distance-aware mode holding, and pressure anti-repeat sizing
+# Output: OrderIntent and per-side execution state transitions (including fill-rate feedback/TTL override, reconcile-safe timeout/preempt/orphan recovery, reduce-only block latching, liq-distance-aware mode holding, order-price notional caps, and pressure qty jitter/anti-repeat with optional shared sizing modifiers)
+# Pos: per-side execution state machine with WS/REST fill meta handling, terminal-state recovery, panic-close-safe orphan repair, same-side close-order block handling, liq-distance-aware mode holding, and order-price-bounded pressure anti-repeat sizing
 # 一旦我被更新，务必更新我的开头注释，以及所属文件夹的MD。
 
 """
@@ -488,12 +488,20 @@ class ExecutionEngine:
             logger.debug(f"{signal.symbol} {signal.position_side.value} 仓位已完成")
             return None
 
+        price, time_in_force = self._resolve_signal_price_and_tif(
+            signal=signal,
+            rules=rules,
+            market_state=market_state,
+            state=state,
+        )
+
         # 计算下单数量
         qty = self.compute_qty(
             position_amt=position_amt,
             min_qty=rules.min_qty,
             step_size=rules.step_size,
             last_trade_price=market_state.last_trade_price,
+            notional_price=price,
             roi_mult=signal.roi_mult,
             accel_mult=signal.accel_mult,
             base_mult_override=signal.base_mult_override,
@@ -505,13 +513,6 @@ class ExecutionEngine:
         if qty <= Decimal("0"):
             logger.debug(f"{signal.symbol} {signal.position_side.value} 计算数量为 0")
             return None
-
-        price, time_in_force = self._resolve_signal_price_and_tif(
-            signal=signal,
-            rules=rules,
-            market_state=market_state,
-            state=state,
-        )
 
         # 确定下单方向
         # LONG 平仓 -> SELL, SHORT 平仓 -> BUY
@@ -1598,6 +1599,7 @@ class ExecutionEngine:
         roi_mult: int = 1,
         accel_mult: int = 1,
         *,
+        notional_price: Optional[Decimal] = None,
         base_mult_override: Optional[int] = None,
         qty_jitter_pct: Decimal = Decimal("0"),
         anti_repeat_lookback: int = 0,
@@ -1617,6 +1619,7 @@ class ExecutionEngine:
             min_qty: 最小下单量
             step_size: 数量步进
             last_trade_price: 最近成交价
+            notional_price: 用于订单名义金额上限的价格；默认沿用最近成交价
 
         Returns:
             下单数量
@@ -1637,10 +1640,15 @@ class ExecutionEngine:
 
         base_qty = min_qty * final_mult
         qty = min(base_qty, abs_position)
+        effective_notional_price = (
+            notional_price
+            if notional_price is not None and notional_price > Decimal("0")
+            else last_trade_price
+        )
 
         # 不超过 max_order_notional
-        if last_trade_price > Decimal("0") and self.max_order_notional > Decimal("0"):
-            max_qty_by_notional = self.max_order_notional / last_trade_price
+        if effective_notional_price > Decimal("0") and self.max_order_notional > Decimal("0"):
+            max_qty_by_notional = self.max_order_notional / effective_notional_price
             qty = min(qty, max_qty_by_notional)
 
         # 按 step_size 规整
@@ -1661,8 +1669,8 @@ class ExecutionEngine:
             min(
                 abs_position,
                 (
-                    self.max_order_notional / last_trade_price
-                    if last_trade_price > Decimal("0") and self.max_order_notional > Decimal("0")
+                    self.max_order_notional / effective_notional_price
+                    if effective_notional_price > Decimal("0") and self.max_order_notional > Decimal("0")
                     else abs_position
                 ),
                 qty * (Decimal("1") + qty_jitter_pct),

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,6 @@
 # Input: config path, env vars, OS signals, account positions, Telegram Bot commands, and recent pressure logs
-# Output: application lifecycle, async tasks, runtime symbol orchestration, account-event position refresh, pause/resume control, reduce-only block verification wiring, liq-distance risk log/mode coordination, and side-adjusted pressure recap/report summaries
-# Pos: application entrypoint and orchestrator for runtime tasks, alerts, and side-adjusted pressure summaries
+# Output: application lifecycle, async tasks, runtime symbol orchestration, account-event position refresh, pause/resume control, reduce-only block verification wiring, orderbook_price revalidation, liq-distance risk log/mode coordination, and side-adjusted pressure recap/report summaries
+# Pos: application entrypoint and orchestrator for runtime tasks, alerts, orderbook_price current-book guards, and side-adjusted pressure summaries
 # 一旦我被更新，务必更新我的开头注释，以及所属文件夹的MD。
 
 """
@@ -2453,13 +2453,39 @@ class Application:
             current_ms=current_time_ms(),
         )
 
+    @staticmethod
+    def _is_orderbook_price_signal_still_valid(signal: ExitSignal, market_state: MarketState) -> bool:
+        if signal.strategy_mode != StrategyMode.ORDERBOOK_PRICE:
+            return True
+        if market_state.previous_trade_price is None:
+            return False
+        if (
+            market_state.best_bid <= Decimal("0")
+            or market_state.best_ask <= Decimal("0")
+            or market_state.last_trade_price <= Decimal("0")
+        ):
+            return False
+
+        last = market_state.last_trade_price
+        prev = market_state.previous_trade_price
+        if signal.reason in (SignalReason.LONG_PRIMARY, SignalReason.LONG_BID_IMPROVE):
+            return (last > prev and market_state.best_bid >= last) or (
+                market_state.best_bid >= last and market_state.best_bid > prev
+            )
+        if signal.reason in (SignalReason.SHORT_PRIMARY, SignalReason.SHORT_ASK_IMPROVE):
+            return (last < prev and market_state.best_ask <= last) or (
+                market_state.best_ask <= last and market_state.best_ask < prev
+            )
+
+        return False
+
     async def _evaluate_side(
         self,
         symbol: str,
         position_side: PositionSide,
         engine: ExecutionEngine,
         rules: SymbolRules,
-        market_state,
+        market_state: MarketState,
         current_ms: int,
     ) -> None:
         """评估单侧仓位"""
@@ -2553,6 +2579,14 @@ class Application:
                 target_mode = ExecutionMode.AGGRESSIVE_LIMIT
                 if state.mode != target_mode:
                     engine.set_mode(symbol, position_side, target_mode, reason="risk_trigger")
+
+            if not self._is_orderbook_price_signal_still_valid(signal, market_state):
+                get_logger().debug(
+                    f"{symbol} {position_side.value} orderbook_price 信号已失效，跳过下单 | "
+                    f"reason={signal.reason.value} | bid={market_state.best_bid} | ask={market_state.best_ask} "
+                    f"| last={market_state.last_trade_price} | prev={market_state.previous_trade_price}"
+                )
+                return
 
             # 主动信号抢占被动单
             state = engine.get_state(symbol, position_side)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,5 +1,5 @@
 # Input: 执行引擎与 pytest 夹具
-# Output: 状态机行为断言与执行反馈校验（含成交率、撤单/成交竞态、orphan 恢复与 reduce-only 挂单占仓回归）
+# Output: 状态机行为断言与执行反馈校验（含成交率、撤单/成交竞态、orphan 恢复、reduce-only 挂单占仓与名义金额硬上限回归）
 # Pos: ExecutionEngine 测试用例与撤单竞态、panic close、自恢复安全回归
 # 一旦我被更新，务必更新我的开头注释，以及所属文件夹的MD。
 
@@ -297,6 +297,61 @@ class TestOrderbookPressureExecution:
         assert state.current_order_execution_preference == SignalExecutionPreference.AGGRESSIVE
         assert state.current_order_strategy_mode == StrategyMode.ORDERBOOK_PRESSURE
         assert state.current_order_cooldown_ms_override == 1000
+
+    @pytest.mark.asyncio
+    async def test_on_signal_caps_pressure_qty_by_order_price_when_last_trade_missing(
+        self,
+        mock_place_order,
+        mock_cancel_order,
+    ):
+        engine = ExecutionEngine(
+            place_order=mock_place_order,
+            cancel_order=mock_cancel_order,
+            base_mult=100,
+            max_mult=100,
+            max_order_notional=Decimal("10"),
+        )
+        rules = SymbolRules(
+            symbol="BTC/USDT:USDT",
+            tick_size=Decimal("0.1"),
+            step_size=Decimal("1"),
+            min_qty=Decimal("1"),
+            min_notional=Decimal("5"),
+        )
+        market_state = MarketState(
+            symbol="BTC/USDT:USDT",
+            best_bid=Decimal("5"),
+            best_ask=Decimal("5.1"),
+            last_trade_price=Decimal("0"),
+            previous_trade_price=None,
+            last_update_ms=1000,
+            is_ready=True,
+        )
+        signal = ExitSignal(
+            symbol="BTC/USDT:USDT",
+            position_side=PositionSide.LONG,
+            reason=SignalReason.LONG_BID_PRESSURE_ACTIVE,
+            timestamp_ms=1000,
+            best_bid=Decimal("5"),
+            best_ask=Decimal("5.1"),
+            last_trade_price=Decimal("5"),
+            strategy_mode=StrategyMode.ORDERBOOK_PRESSURE,
+            execution_preference=SignalExecutionPreference.AGGRESSIVE,
+            price_override=Decimal("5"),
+            base_mult_override=100,
+        )
+
+        intent = await engine.on_signal(
+            signal=signal,
+            position_amt=Decimal("100"),
+            rules=rules,
+            market_state=market_state,
+            current_ms=1000,
+        )
+
+        assert intent is not None
+        assert intent.qty == Decimal("2")
+        assert intent.price == Decimal("5")
 
     @pytest.mark.asyncio
     async def test_on_signal_uses_post_only_tif_for_passive_price_override(self, engine, symbol_rules, market_state):

--- a/tests/test_main_shutdown.py
+++ b/tests/test_main_shutdown.py
@@ -1,6 +1,6 @@
 # Input: 被测模块与 pytest 夹具
 # Output: pytest 断言结果
-# Pos: 测试用例（main.py 关闭行为 + 命令解析 + 保护止损调度竞态）
+# Pos: 测试用例（main.py 关闭行为 + 命令解析 + 保护止损调度竞态 + orderbook_price 机会重校验）
 # 一旦我被更新，务必更新我的开头注释，以及所属文件夹的MD。
 
 """
@@ -857,6 +857,49 @@ async def test_evaluate_side_risk_does_not_promote_pressure_passive_signal():
     assert signal.price_override == Decimal("9.8")
     assert signal.ttl_override_ms == 10000
     assert signal.cooldown_override_ms == 0
+
+
+@pytest.mark.asyncio
+async def test_evaluate_side_skips_orderbook_price_signal_when_current_book_no_longer_valid():
+    symbol = "DASH/USDT:USDT"
+    signal = ExitSignal(
+        symbol=symbol,
+        position_side=PositionSide.LONG,
+        reason=SignalReason.LONG_BID_IMPROVE,
+        timestamp_ms=1000,
+        best_bid=Decimal("10.2"),
+        best_ask=Decimal("10.3"),
+        last_trade_price=Decimal("10"),
+        strategy_mode=StrategyMode.ORDERBOOK_PRICE,
+    )
+    app, engine = _make_pressure_eval_app(
+        position_side=PositionSide.LONG,
+        position_amt=Decimal("5"),
+        signal=signal,
+        risk_triggered=False,
+    )
+    engine.on_signal = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    current_market_state = MarketState(
+        symbol=symbol,
+        best_bid=Decimal("9.8"),
+        best_ask=Decimal("10.3"),
+        last_trade_price=Decimal("10"),
+        previous_trade_price=Decimal("9.9"),
+        last_update_ms=1000,
+        is_ready=True,
+    )
+
+    await app._evaluate_side(
+        symbol=symbol,
+        position_side=PositionSide.LONG,
+        engine=engine,
+        rules=app._rules[symbol],
+        market_state=current_market_state,
+        current_ms=1000,
+    )
+
+    engine.on_signal.assert_not_awaited()
+    assert engine.get_state(symbol, PositionSide.LONG).mode == ExecutionMode.MAKER_ONLY
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Revalidate orderbook_price signals against the current in-memory MarketState before handing them to execution.
- Cap order quantity by the resolved order limit price, so orderbook_pressure remains bounded by max_order_notional even when last_trade_price is missing.
- Update regression tests and docs for the current safety semantics.

## Root Cause
- orderbook_price signals could be evaluated on one book snapshot and then executed after the opportunity had disappeared.
- compute_qty only used last_trade_price for max_order_notional, while orderbook_pressure can be ready without aggTrade data.

## Validation
- PYTHONDONTWRITEBYTECODE=1 uv run python -m pytest -q -p no:cacheprovider
- uv run pyright src/
- Independent read-only reviewer: no blocking findings; recommended merge.
