### PR TITLE
[codex] Mark release-readiness issues closed

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -69,9 +69,9 @@ Roadmap issues should describe concrete release-readiness work. Good issue topic
 
 Do not create placeholder issues only to increase repository activity.
 
-Current release-readiness tracking issues:
+Tracked release-readiness issues for `v0.1.0`:
 
-- [#18 Prepare v0.1.0 release checklist](https://github.com/jackhai9/binance-exit-executor/issues/18)
-- [#19 Add small-size production validation walkthrough](https://github.com/jackhai9/binance-exit-executor/issues/19)
-- [#20 Document operator dry-run and minimal-permission setup](https://github.com/jackhai9/binance-exit-executor/issues/20)
-- [#21 Expand reconnect and risk regression evidence before v0.1.0](https://github.com/jackhai9/binance-exit-executor/issues/21)
+- [#18 Prepare v0.1.0 release checklist](https://github.com/jackhai9/binance-exit-executor/issues/18) - closed
+- [#19 Add small-size production validation walkthrough](https://github.com/jackhai9/binance-exit-executor/issues/19) - closed
+- [#20 Document operator dry-run and minimal-permission setup](https://github.com/jackhai9/binance-exit-executor/issues/20) - closed
+- [#21 Expand reconnect and risk regression evidence before v0.1.0](https://github.com/jackhai9/binance-exit-executor/issues/21) - closed

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -24,9 +24,9 @@ Before creating the tag and GitHub Release:
 - [x] Confirm operator safety guidance exists and is linked from the README.
 - [x] Run `uv run pyright src/`.
 - [x] Run `uv run pytest -q`.
+- [x] Document small-size production validation workflow in `docs/production-validation.md`.
 - [x] Document reconnect and risk regression evidence in `docs/regression-evidence.md`.
 - [x] Confirm no tag or GitHub Release has been created by this checklist work.
-- [ ] Decide whether #19 small-size production validation walkthrough must be completed before tagging `v0.1.0`.
 - [ ] Re-run release validation on the exact commit that will be tagged.
 
 ## Validation Evidence
@@ -45,13 +45,13 @@ These commands were run for checklist preparation only. Re-run them on the exact
 
 ## Open Release-Readiness Work
 
-- [#19 Add small-size production validation walkthrough](https://github.com/jackhai9/binance-exit-executor/issues/19)
+No tracked release-readiness issue remains open for `v0.1.0`.
 
 Recommended release decision:
 
-- `v0.1.0` can be prepared as an early operator-controlled release only if release notes clearly list #19 as not yet completed, or if #19 is completed before tagging.
-- If the release is intended to claim maintainer production validation, complete #19 and record sanitized evidence before tagging.
-- If the release is intended as a repository milestone for the current maintainer, #19 may remain open only when the release notes keep the unverified integration areas explicit.
+- `v0.1.0` can be prepared as an early operator-controlled release with the current documentation set.
+- If the release is intended to claim maintainer production validation on the tagged commit, complete the small-size production validation workflow and record sanitized evidence before tagging.
+- If the release is intended as a repository milestone for the current maintainer, keep the release notes explicit about live-system areas that remain unverified.
 
 ## Draft GitHub Release Notes
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -89,6 +89,17 @@
 - `docs/release.md` / `docs/releases/v0.1.0.md`：将 reconnect/risk regression evidence 接入 release gate 和 release notes 草案
 - `docs/README.md`：新增 regression evidence 文档入口
 
+## Milestone/附加改进：v0.1.0 release-readiness issue 收口
+
+**状态**：✅ 已完成<br>
+**日期**：2026-06-15
+
+**动机**：`#18`、`#19`、`#20`、`#21` 已全部关闭后，release 文档不能继续把已关闭 issue 描述为 open release-readiness work。<br>
+**产出**：
+
+- `docs/release.md`：将 `v0.1.0` tracked release-readiness issues 标注为 closed
+- `docs/releases/v0.1.0.md`：将 open release-readiness work 收口为 none，保留 tagged commit 上 fresh 小额主网验证仍需按 release decision 单独执行的边界
+
 ## Milestone/附加改进：退出机会与订单名义金额硬约束
 
 **状态**：✅ 已完成<br>


### PR DESCRIPTION
## Summary
- Mark the tracked `v0.1.0` release-readiness issues as closed in the release guide.
- Update the `v0.1.0` checklist so open release-readiness work is `none`.
- Keep the release decision boundary explicit: fresh small-size production validation on the tagged commit is still a separate operator decision before claiming production validation.

## Validation
- `git diff --check` -> passed
- `uv run pyright src/` -> 0 errors, 0 warnings, 0 informations
- `uv run pytest -q` -> 472 passed

## Notes
- Documentation-only change.
- No tag, GitHub Release, deployment, production interaction, or trade was performed.
